### PR TITLE
121 add conversion factors to wrist and elevator subsystems

### DIFF
--- a/src/main/java/org/jmhsrobotics/frc2025/Constants.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/Constants.java
@@ -70,10 +70,10 @@ public final class Constants {
     public static final double kAlgaeIntakeL2Meters = .55;
     public static final double kAlgaeIntakeL3Meters = 0.95;
 
-    public static final double kP = .01;
+    public static final double kP = .5;
     public static final double kI = .00;
     public static final double kD = .00;
-    public static final double kHeightTolerance = 0.1;
+    public static final double kHeightTolerance = 0.05;
   }
 
   public static class WristConstants {

--- a/src/main/java/org/jmhsrobotics/frc2025/Constants.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/Constants.java
@@ -92,7 +92,7 @@ public final class Constants {
     public static final double kRotationBargeDegrees = 90;
     public static final double kRotationQTipDegrees = 195;
 
-    public static final double kP = 0.02;
+    public static final double kP = 0.005;
     public static final double kI = 0.00;
     public static final double kD = 0.00;
     public static final double kAngleTolerance = 2;

--- a/src/main/java/org/jmhsrobotics/frc2025/Constants.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/Constants.java
@@ -80,24 +80,24 @@ public final class Constants {
 
     // TODO: When absolute encoder conversion is fixed, remove  / 360, recalibrate PID and change
     // tolerance to 1 degree;
-    public static final double kRotationIntakeCoralDegrees = 20.0 / 360.0;
+    public static final double kRotationIntakeCoralDegrees = 20;
 
-    public static final double kLevel1Degrees = 30.0 / 360.0;
-    public static final double kLevel2Degrees = 44.0 / 360.0;
-    public static final double kLevel3Degrees = 44.0 / 360.0;
-    public static final double kLevel4Degrees = 95.0 / 360.0;
+    public static final double kLevel1Degrees = 30.0;
+    public static final double kLevel2Degrees = 44.0;
+    public static final double kLevel3Degrees = 44.0;
+    public static final double kLevel4Degrees = 95.0;
 
-    public static final double kRotationAlgaeDegrees = 200.0 / 360.0;
-    public static final double kRotationProcesserDegrees = 190.0 / 360.0;
-    public static final double kRotationBargeDegrees = 90.0 / 360.0;
-    public static final double kRotationQTipDegrees = 195.0 / 360.0;
+    public static final double kRotationAlgaeDegrees = 200;
+    public static final double kRotationProcesserDegrees = 190;
+    public static final double kRotationBargeDegrees = 90;
+    public static final double kRotationQTipDegrees = 195;
 
-    public static final double kP = 0.6;
+    public static final double kP = 0.02;
     public static final double kI = 0.00;
     public static final double kD = 0.00;
-    public static final double kAngleTolerance = 0.01;
+    public static final double kAngleTolerance = 2;
 
-    public static final double kSafeAngleDegrees = 40.0 / 360.0;
+    public static final double kSafeAngleDegrees = 40;
   }
 
   public static class IntakeConstants {

--- a/src/main/java/org/jmhsrobotics/frc2025/Constants.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/Constants.java
@@ -90,10 +90,10 @@ public final class Constants {
     public static final double kRotationBargeDegrees = 0;
     public static final double kRotationQTipDegrees = 105;
 
-    public static final double kP = 0.01;
+    public static final double kP = 0.02;
     public static final double kI = 0.00;
     public static final double kD = 0.00;
-    public static final double kAngleTolerance = 3;
+    public static final double kAngleTolerance = 0.1;
 
     public static final double kSafeAngleDegrees = -50;
   }

--- a/src/main/java/org/jmhsrobotics/frc2025/Constants.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/Constants.java
@@ -78,24 +78,26 @@ public final class Constants {
 
   public static class WristConstants {
 
-    public static final double kRotationIntakeCoralDegrees = -70;
+    // TODO: When absolute encoder conversion is fixed, remove  / 360, recalibrate PID and change
+    // tolerance to 1 degree;
+    public static final double kRotationIntakeCoralDegrees = 20.0 / 360.0;
 
-    public static final double kLevel1Degrees = -60;
-    public static final double kLevel2Degrees = -46;
-    public static final double kLevel3Degrees = -46;
-    public static final double kLevel4Degrees = 5;
+    public static final double kLevel1Degrees = 30.0 / 360.0;
+    public static final double kLevel2Degrees = 44.0 / 360.0;
+    public static final double kLevel3Degrees = 44.0 / 360.0;
+    public static final double kLevel4Degrees = 95.0 / 360.0;
 
-    public static final double kRotationAlgaeDegrees = 110;
-    public static final double kRotationProcesserDegrees = 100;
-    public static final double kRotationBargeDegrees = 0;
-    public static final double kRotationQTipDegrees = 105;
+    public static final double kRotationAlgaeDegrees = 200.0 / 360.0;
+    public static final double kRotationProcesserDegrees = 190.0 / 360.0;
+    public static final double kRotationBargeDegrees = 90.0 / 360.0;
+    public static final double kRotationQTipDegrees = 195.0 / 360.0;
 
-    public static final double kP = 0.02;
+    public static final double kP = 0.6;
     public static final double kI = 0.00;
     public static final double kD = 0.00;
-    public static final double kAngleTolerance = 0.1;
+    public static final double kAngleTolerance = 0.01;
 
-    public static final double kSafeAngleDegrees = -50;
+    public static final double kSafeAngleDegrees = 40.0 / 360.0;
   }
 
   public static class IntakeConstants {

--- a/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
@@ -389,7 +389,9 @@ public class RobotContainer {
         new WristMoveTo(wrist, Constants.WristConstants.kRotationIntakeCoralDegrees));
     SmartDashboard.putData(
         "WristScoreLevel4", new WristMoveTo(wrist, Constants.WristConstants.kLevel4Degrees));
-    SmartDashboard.putData("ElevatorUpSafe", new ElevatorMoveTo(elevator, 0.2));
+    SmartDashboard.putData(
+        "WristScoreLevel2", new WristMoveTo(wrist, Constants.WristConstants.kLevel2Degrees));
+    SmartDashboard.putData("ElevatorUpSafe", new ElevatorMoveTo(elevator, 0.5));
     SmartDashboard.putData("ElevatorDownSafe", new ElevatorMoveTo(elevator, 0));
   }
 

--- a/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
@@ -383,7 +383,7 @@ public class RobotContainer {
     SmartDashboard.putData(
         "ResetIndexerPosition",
         new ClimberAndIndexerMove(climber, 0, Constants.IndexerConstants.kRotationDownDegrees));
-    SmartDashboard.putData("RunElevatorZeroCommand", new ElevatorSetZero(elevator));
+    SmartDashboard.putData("ElevatorZeroCommand", new ElevatorSetZero(elevator));
     SmartDashboard.putData("WristToZeroCommand", new WristMoveTo(wrist, 0));
     SmartDashboard.putData("WristToTwentyCommand", new WristMoveTo(wrist, 20));
     SmartDashboard.putData("ElevatorUpSafe", new ElevatorMoveTo(elevator, 0.2));

--- a/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
@@ -384,10 +384,13 @@ public class RobotContainer {
         "ResetIndexerPosition",
         new ClimberAndIndexerMove(climber, 0, Constants.IndexerConstants.kRotationDownDegrees));
     SmartDashboard.putData("ElevatorZeroCommand", new ElevatorSetZero(elevator));
-    SmartDashboard.putData("WristToZeroCommand", new WristMoveTo(wrist, 0));
-    SmartDashboard.putData("WristToTwentyCommand", new WristMoveTo(wrist, 20));
+    SmartDashboard.putData(
+        "WristCoralIntake",
+        new WristMoveTo(wrist, Constants.WristConstants.kRotationIntakeCoralDegrees));
+    SmartDashboard.putData(
+        "WristScoreLevel4", new WristMoveTo(wrist, Constants.WristConstants.kLevel4Degrees));
     SmartDashboard.putData("ElevatorUpSafe", new ElevatorMoveTo(elevator, 0.2));
-    SmartDashboard.putData("ClimberDownSafe", new ElevatorMoveTo(elevator, 0));
+    SmartDashboard.putData("ElevatorDownSafe", new ElevatorMoveTo(elevator, 0));
   }
 
   /**

--- a/src/main/java/org/jmhsrobotics/frc2025/commands/ElevatorSetZero.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/commands/ElevatorSetZero.java
@@ -17,13 +17,13 @@ public class ElevatorSetZero extends Command {
   @Override
   public void initialize() {
     timer.reset();
-    elevator.setVoltage(-1);
+    elevator.setVoltage(-5);
   }
 
   @Override
   public void execute() {
     // if the velocity is at or near zero, the timer starts. otherwise it is reset to 0
-    if (elevator.getCurrentAmps() > 2) timer.start();
+    if (elevator.getCurrentAmps() > 110) timer.start();
     else timer.reset();
   }
 

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/elevator/Elevator.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/elevator/Elevator.java
@@ -33,7 +33,7 @@ public class Elevator extends SubsystemBase {
 
     Logger.recordOutput("Elevator/Current", this.getCurrentAmps());
     Logger.recordOutput("Elevator/Height", inputs.heightMeters);
-    Logger.recordOutput("Elevator/Setpoint Value", inputs.setPointMeters);
+    Logger.recordOutput("Elevator/Setpoint Value", setPointMeters);
   }
 
   public boolean atGoal() {

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/elevator/VortexElevatorIO.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/elevator/VortexElevatorIO.java
@@ -41,6 +41,13 @@ public class VortexElevatorIO implements ElevatorIO {
         .inverted(true)
         .encoder
         .positionConversionFactor(Constants.ElevatorConstants.conversionFactor);
+    vortexLeftConfig
+        .closedLoop
+        .pid(
+            Constants.ElevatorConstants.kP,
+            Constants.ElevatorConstants.kI,
+            Constants.ElevatorConstants.kD)
+        .outputRange(-0.25, 0.25);
 
     vortexRightConfig = new SparkFlexConfig();
     vortexRightConfig
@@ -51,6 +58,13 @@ public class VortexElevatorIO implements ElevatorIO {
         .follow(vortexLeft)
         .encoder
         .positionConversionFactor(Constants.ElevatorConstants.conversionFactor);
+    vortexRightConfig
+        .closedLoop
+        .pid(
+            Constants.ElevatorConstants.kP,
+            Constants.ElevatorConstants.kI,
+            Constants.ElevatorConstants.kD)
+        .outputRange(-0.25, 0.25);
 
     SparkUtil.tryUntilOk(
         vortexLeft,

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
@@ -27,6 +27,8 @@ public class NeoWristIO implements WristIO {
   private double setPointDegrees = Constants.WristConstants.kRotationIntakeCoralDegrees;
 
   public NeoWristIO() {
+    encoderConfig.positionConversionFactor(360);
+
     motorConfig
         .idleMode(IdleMode.kBrake)
         .smartCurrentLimit(40)
@@ -45,8 +47,8 @@ public class NeoWristIO implements WristIO {
         .pid(Constants.WristConstants.kP, Constants.WristConstants.kI, Constants.WristConstants.kD)
         .outputRange(-0.25, 0.25)
         .feedbackSensor(FeedbackSensor.kAbsoluteEncoder);
+    motorConfig.absoluteEncoder.apply(encoderConfig);
 
-    encoderConfig.positionConversionFactor(360);
     SparkUtil.tryUntilOk(
         motor,
         5,

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
@@ -11,6 +11,7 @@ import com.revrobotics.spark.config.AbsoluteEncoderConfig;
 import com.revrobotics.spark.config.ClosedLoopConfig.FeedbackSensor;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkMaxConfig;
+import edu.wpi.first.math.util.Units;
 import org.jmhsrobotics.frc2025.Constants;
 import org.jmhsrobotics.frc2025.util.SparkUtil;
 
@@ -45,7 +46,7 @@ public class NeoWristIO implements WristIO {
     motorConfig
         .closedLoop
         .pid(Constants.WristConstants.kP, Constants.WristConstants.kI, Constants.WristConstants.kD)
-        .outputRange(-0.25, 0.25)
+        .outputRange(-0.5, 0.5)
         .feedbackSensor(FeedbackSensor.kAbsoluteEncoder);
     motorConfig.absoluteEncoder.apply(encoderConfig);
 
@@ -62,7 +63,10 @@ public class NeoWristIO implements WristIO {
   @Override
   public void updateInputs(WristIOInputs inputs) {
     SparkUtil.sparkStickyFault = false;
-    SparkUtil.ifOk(motor, encoder::getPosition, (value) -> inputs.positionDegrees = value);
+    SparkUtil.ifOk(
+        motor,
+        encoder::getPosition,
+        (value) -> inputs.positionDegrees = Units.rotationsToDegrees(value));
 
     SparkUtil.ifOk(motor, motor::getOutputCurrent, (value) -> inputs.motorAmps = value);
     SparkUtil.ifOk(motor, encoder::getVelocity, (value) -> inputs.motorRPM = value);

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
@@ -1,7 +1,6 @@
 package org.jmhsrobotics.frc2025.subsystems.wrist;
 
 import com.revrobotics.AbsoluteEncoder;
-import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkBase.ControlType;
 import com.revrobotics.spark.SparkBase.PersistMode;
 import com.revrobotics.spark.SparkBase.ResetMode;
@@ -17,8 +16,7 @@ import org.jmhsrobotics.frc2025.util.SparkUtil;
 
 public class NeoWristIO implements WristIO {
   private SparkMax motor = new SparkMax(Constants.CAN.kWristMotorID, MotorType.kBrushless);
-  private AbsoluteEncoder encoder;
-  private RelativeEncoder relativeEncoder;
+  private AbsoluteEncoder encoder = motor.getAbsoluteEncoder();
 
   private SparkMaxConfig motorConfig = new SparkMaxConfig();
   private AbsoluteEncoderConfig encoderConfig = new AbsoluteEncoderConfig();
@@ -26,7 +24,7 @@ public class NeoWristIO implements WristIO {
   private SparkClosedLoopController pidController;
   // P:0.02
 
-  private double setPointDegrees;
+  private double setPointDegrees = Constants.WristConstants.kRotationIntakeCoralDegrees;
 
   public NeoWristIO() {
     motorConfig
@@ -49,8 +47,6 @@ public class NeoWristIO implements WristIO {
         .feedbackSensor(FeedbackSensor.kAbsoluteEncoder);
 
     encoderConfig.positionConversionFactor(360);
-    encoder = motor.getAbsoluteEncoder();
-
     SparkUtil.tryUntilOk(
         motor,
         5,
@@ -70,8 +66,6 @@ public class NeoWristIO implements WristIO {
     SparkUtil.ifOk(motor, encoder::getVelocity, (value) -> inputs.motorRPM = value);
 
     pidController.setReference(setPointDegrees, ControlType.kPosition);
-
-    inputs.relativePositionDegrees = motor.getEncoder().getPosition();
   }
 
   @Override

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
@@ -7,6 +7,7 @@ import com.revrobotics.spark.SparkBase.ResetMode;
 import com.revrobotics.spark.SparkClosedLoopController;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.SparkMax;
+import com.revrobotics.spark.config.AbsoluteEncoderConfig;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkMaxConfig;
 import edu.wpi.first.math.util.Units;
@@ -18,6 +19,7 @@ public class NeoWristIO implements WristIO {
   private AbsoluteEncoder encoder;
 
   private SparkMaxConfig motorConfig = new SparkMaxConfig();
+  private AbsoluteEncoderConfig encoderConfig = new AbsoluteEncoderConfig();
 
   private SparkClosedLoopController pidController;
   // P:0.02
@@ -29,7 +31,17 @@ public class NeoWristIO implements WristIO {
         .idleMode(IdleMode.kBrake)
         .smartCurrentLimit(40)
         .voltageCompensation(12)
-        .inverted(false);
+        .inverted(false)
+        .signals
+        .absoluteEncoderVelocityAlwaysOn(true)
+        .absoluteEncoderPositionAlwaysOn(true)
+        .absoluteEncoderPositionPeriodMs(20)
+        .absoluteEncoderVelocityPeriodMs(20)
+        .appliedOutputPeriodMs(20)
+        .busVoltagePeriodMs(20)
+        .outputCurrentPeriodMs(20);
+
+    encoderConfig.positionConversionFactor(360);
 
     SparkUtil.tryUntilOk(
         motor,
@@ -44,7 +56,6 @@ public class NeoWristIO implements WristIO {
 
   @Override
   public void updateInputs(WristIOInputs inputs) {
-    // getPosition() multiplied by 360 to convert from rotations to degrees
     SparkUtil.sparkStickyFault = false;
     SparkUtil.ifOk(
         motor,

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
@@ -1,6 +1,7 @@
 package org.jmhsrobotics.frc2025.subsystems.wrist;
 
 import com.revrobotics.AbsoluteEncoder;
+import com.revrobotics.RelativeEncoder;
 import com.revrobotics.spark.SparkBase.ControlType;
 import com.revrobotics.spark.SparkBase.PersistMode;
 import com.revrobotics.spark.SparkBase.ResetMode;
@@ -8,15 +9,16 @@ import com.revrobotics.spark.SparkClosedLoopController;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.AbsoluteEncoderConfig;
+import com.revrobotics.spark.config.ClosedLoopConfig.FeedbackSensor;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkMaxConfig;
-import edu.wpi.first.math.util.Units;
 import org.jmhsrobotics.frc2025.Constants;
 import org.jmhsrobotics.frc2025.util.SparkUtil;
 
 public class NeoWristIO implements WristIO {
   private SparkMax motor = new SparkMax(Constants.CAN.kWristMotorID, MotorType.kBrushless);
   private AbsoluteEncoder encoder;
+  private RelativeEncoder relativeEncoder;
 
   private SparkMaxConfig motorConfig = new SparkMaxConfig();
   private AbsoluteEncoderConfig encoderConfig = new AbsoluteEncoderConfig();
@@ -40,8 +42,14 @@ public class NeoWristIO implements WristIO {
         .appliedOutputPeriodMs(20)
         .busVoltagePeriodMs(20)
         .outputCurrentPeriodMs(20);
+    motorConfig
+        .closedLoop
+        .pid(Constants.WristConstants.kP, Constants.WristConstants.kI, Constants.WristConstants.kD)
+        .outputRange(-0.25, 0.25)
+        .feedbackSensor(FeedbackSensor.kAbsoluteEncoder);
 
     encoderConfig.positionConversionFactor(360);
+    encoder = motor.getAbsoluteEncoder();
 
     SparkUtil.tryUntilOk(
         motor,
@@ -50,22 +58,20 @@ public class NeoWristIO implements WristIO {
             motor.configure(
                 motorConfig, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters));
 
-    encoder = motor.getAbsoluteEncoder();
     pidController = motor.getClosedLoopController();
   }
 
   @Override
   public void updateInputs(WristIOInputs inputs) {
     SparkUtil.sparkStickyFault = false;
-    SparkUtil.ifOk(
-        motor,
-        encoder::getPosition,
-        (value) -> inputs.positionDegrees = Units.rotationsToDegrees(value));
+    SparkUtil.ifOk(motor, encoder::getPosition, (value) -> inputs.positionDegrees = value);
 
     SparkUtil.ifOk(motor, motor::getOutputCurrent, (value) -> inputs.motorAmps = value);
     SparkUtil.ifOk(motor, encoder::getVelocity, (value) -> inputs.motorRPM = value);
 
     pidController.setReference(setPointDegrees, ControlType.kPosition);
+
+    inputs.relativePositionDegrees = motor.getEncoder().getPosition();
   }
 
   @Override

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/NeoWristIO.java
@@ -11,7 +11,6 @@ import com.revrobotics.spark.config.AbsoluteEncoderConfig;
 import com.revrobotics.spark.config.ClosedLoopConfig.FeedbackSensor;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkMaxConfig;
-import edu.wpi.first.math.util.Units;
 import org.jmhsrobotics.frc2025.Constants;
 import org.jmhsrobotics.frc2025.util.SparkUtil;
 
@@ -63,10 +62,7 @@ public class NeoWristIO implements WristIO {
   @Override
   public void updateInputs(WristIOInputs inputs) {
     SparkUtil.sparkStickyFault = false;
-    SparkUtil.ifOk(
-        motor,
-        encoder::getPosition,
-        (value) -> inputs.positionDegrees = Units.rotationsToDegrees(value));
+    SparkUtil.ifOk(motor, encoder::getPosition, (value) -> inputs.positionDegrees = value);
 
     SparkUtil.ifOk(motor, motor::getOutputCurrent, (value) -> inputs.motorAmps = value);
     SparkUtil.ifOk(motor, encoder::getVelocity, (value) -> inputs.motorRPM = value);

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/Wrist.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/Wrist.java
@@ -17,6 +17,9 @@ public class Wrist extends SubsystemBase {
   public void periodic() {
     wristIO.updateInputs(inputs);
     Logger.recordOutput("Wrist/AngleDegrees", inputs.positionDegrees);
+    Logger.recordOutput("Wrist/OutputCurrent", inputs.motorAmps);
+    Logger.recordOutput("Wrist/GoalAngle", setPointDegrees);
+    Logger.recordOutput("Wrist/RelativeEncoderPosition", inputs.relativePositionDegrees);
   }
 
   public boolean atGoal() {

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/Wrist.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/Wrist.java
@@ -7,7 +7,7 @@ import org.littletonrobotics.junction.Logger;
 public class Wrist extends SubsystemBase {
   private WristIO wristIO;
   private WristIOInputsAutoLogged inputs = new WristIOInputsAutoLogged();
-  private double setPointDegrees;
+  private double setPointDegrees = Constants.WristConstants.kRotationIntakeCoralDegrees;
 
   public Wrist(WristIO wristIO) {
     this.wristIO = wristIO;
@@ -19,7 +19,6 @@ public class Wrist extends SubsystemBase {
     Logger.recordOutput("Wrist/AngleDegrees", inputs.positionDegrees);
     Logger.recordOutput("Wrist/OutputCurrent", inputs.motorAmps);
     Logger.recordOutput("Wrist/GoalAngle", setPointDegrees);
-    Logger.recordOutput("Wrist/RelativeEncoderPosition", inputs.relativePositionDegrees);
   }
 
   public boolean atGoal() {

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/Wrist.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/Wrist.java
@@ -2,6 +2,7 @@ package org.jmhsrobotics.frc2025.subsystems.wrist;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.jmhsrobotics.frc2025.Constants;
+import org.littletonrobotics.junction.Logger;
 
 public class Wrist extends SubsystemBase {
   private WristIO wristIO;
@@ -15,6 +16,7 @@ public class Wrist extends SubsystemBase {
   @Override
   public void periodic() {
     wristIO.updateInputs(inputs);
+    Logger.recordOutput("Wrist/AngleDegrees", inputs.positionDegrees);
   }
 
   public boolean atGoal() {

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/WristIO.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/WristIO.java
@@ -8,6 +8,7 @@ public interface WristIO {
     public double positionDegrees;
     public double motorRPM;
     public double motorAmps;
+    public double relativePositionDegrees;
   }
 
   public default void updateInputs(WristIOInputs inputs) {}

--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/WristIO.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/wrist/WristIO.java
@@ -8,7 +8,6 @@ public interface WristIO {
     public double positionDegrees;
     public double motorRPM;
     public double motorAmps;
-    public double relativePositionDegrees;
   }
 
   public default void updateInputs(WristIOInputs inputs) {}


### PR DESCRIPTION
Wrist works except absolute encoder is using rotations and sending those values to the PID controller. Elevator should work with PID testing, but the gear ratio seems to be good to measure the height of the elevator relatively accurately