### PR TITLE
Enabled 5VA channel for Mito

### DIFF
--- a/src/main/java/org/jmhsrobotics/frc2025/subsystems/powerSystem/PowerSystem.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/subsystems/powerSystem/PowerSystem.java
@@ -36,6 +36,15 @@ public class PowerSystem extends SubsystemBase {
                 Logger.recordOutput("mito/" + name + "/voltage", current);
               },
               () -> System.out.println("Couldn't get mito-volts: " + channel + " " + name));
+      powerhouse 
+          .setChannelEnabled(MitoCANdria.MITOCANDRIA_CHANNEL_5VA, true);
+          System.out.println("5VA channel enabled");
+      powerhouse
+          .getChannelEnabled(MitoCANdria.MITOCANDRIA_CHANNEL_5VA)
+          .ifPresentOrElse(
+              enabled -> System.out.println("5VA channel enabled: " + (enabled == 1)),
+              () -> System.out.println("Couldn't check if 5VA channel is enabled")
+          );
     } catch (Exception e) {
       System.out.println("Couldn't get mito: " + channel + " " + name);
     }


### PR DESCRIPTION
Enabled 5VA channel for Mito. Closes issue #122. 