### PR TITLE
Bind zero elevator command and make LEDs flash on intake

### DIFF
--- a/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
@@ -27,6 +27,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.ParallelRaceGroup;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import org.jmhsrobotics.frc2025.commands.ClimberAndIndexerMove;
@@ -331,7 +332,7 @@ public class RobotContainer {
                 Constants.ElevatorConstants.kAlgaeQTipMeters,
                 Constants.WristConstants.kRotationAlgaeDegrees));
 
-    control.intakeCoralFromIndexer().onTrue(new IntakeFromIndexer(wrist, intake));
+    control.intakeCoralFromIndexer().onTrue(new ParallelRaceGroup(new IntakeFromIndexer(wrist, intake), new LEDFlashPattern(led, LEDPattern.solid(Color.kTurquoise), LEDPattern.solid(Color.kWhite))));
 
     control
         .climbUp()
@@ -367,13 +368,13 @@ public class RobotContainer {
     new Trigger(intake::isControlModeOverridden)
         .onTrue(
             new LEDFlashPattern(
-                led, LEDPattern.solid(Color.kRed), LEDPattern.solid(Color.kWhite), 1.5));
+                led, LEDPattern.solid(Color.kRed), LEDPattern.solid(Color.kWhite)).withTimeout(1.5));
 
     // if control mode is un-overridden, lights will flash gold and white
     new Trigger(intake::isControlModeOverridden)
         .onFalse(
             new LEDFlashPattern(
-                led, LEDPattern.solid(Color.kGold), LEDPattern.solid(Color.kWhite), 1.5));
+                led, LEDPattern.solid(Color.kGold), LEDPattern.solid(Color.kWhite)).withTimeout(1.5));
   }
 
   private void setupSmartDashbaord() {

--- a/src/main/java/org/jmhsrobotics/frc2025/commands/LEDFlashPattern.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/commands/LEDFlashPattern.java
@@ -8,7 +8,6 @@ import org.jmhsrobotics.frc2025.subsystems.led.LED;
 
 public class LEDFlashPattern extends Command {
   private LED led;
-  private double duration;
   private double interval = 1.0 / Constants.LEDConstants.kFlashFrequency;
 
   private final LEDPattern firstPattern;
@@ -18,9 +17,8 @@ public class LEDFlashPattern extends Command {
   private Timer lightTimer = new Timer();
 
   public LEDFlashPattern(
-      LED led, LEDPattern firstPattern, LEDPattern secondPattern, double duration) {
+      LED led, LEDPattern firstPattern, LEDPattern secondPattern) {
     this.led = led;
-    this.duration = duration;
     this.firstPattern = firstPattern;
     this.secondPattern = secondPattern;
 
@@ -43,11 +41,5 @@ public class LEDFlashPattern extends Command {
       else led.setPattern(firstPattern);
       lightTimer.restart();
     }
-  }
-
-  @Override
-  public boolean isFinished() {
-    // TODO Auto-generated method stub
-    return timer.get() > this.duration;
   }
 }

--- a/src/main/java/org/jmhsrobotics/frc2025/controlBoard/AltControlMode.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/controlBoard/AltControlMode.java
@@ -183,10 +183,10 @@ public class AltControlMode implements ControlBoard {
     return driver.povDown();
   }
 
-  @Override
-  public Trigger indexerUp() {
-    return driver.leftStick();
-  }
+  //@Override
+  //public Trigger indexerUp() {
+  //  return driver.leftStick();
+  //}
 
   @Override
   public Trigger indexerDown() {
@@ -211,5 +211,10 @@ public class AltControlMode implements ControlBoard {
   @Override
   public Trigger resetIndexer() {
     return driver.povLeft();
+  }
+
+  @Override
+  public Trigger zeroElevator(){
+    return driver.leftStick();
   }
 }

--- a/src/main/java/org/jmhsrobotics/frc2025/controlBoard/ControlBoard.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/controlBoard/ControlBoard.java
@@ -48,7 +48,7 @@ public interface ControlBoard {
 
   public Trigger climbDown();
 
-  public Trigger indexerUp();
+  //public Trigger indexerUp();
 
   public Trigger indexerDown();
 
@@ -59,4 +59,6 @@ public interface ControlBoard {
   public Trigger UnOverrideControlMode();
 
   public Trigger resetIndexer();
+
+  public Trigger zeroElevator();
 }

--- a/src/main/java/org/jmhsrobotics/frc2025/controlBoard/DoubleControl.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/controlBoard/DoubleControl.java
@@ -182,10 +182,10 @@ public class DoubleControl implements ControlBoard {
     return operator.povDown();
   }
 
-  @Override
-  public Trigger indexerUp() {
-    return operator.leftStick();
-  }
+  //@Override
+  //public Trigger indexerUp() {
+  //  return operator.leftStick();
+  //}
 
   @Override
   public Trigger indexerDown() {
@@ -210,5 +210,10 @@ public class DoubleControl implements ControlBoard {
   @Override
   public Trigger resetIndexer() {
     return operator.povLeft();
+  }
+
+  @Override
+  public Trigger zeroElevator(){
+    return operator.leftStick();
   }
 }

--- a/src/main/java/org/jmhsrobotics/frc2025/controlBoard/SingleControl.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/controlBoard/SingleControl.java
@@ -164,10 +164,10 @@ public class SingleControl implements ControlBoard {
     return driver.povDown();
   }
 
-  @Override
-  public Trigger indexerUp() {
-    return driver.leftStick();
-  }
+  //@Override
+  //public Trigger indexerUp() {
+  //  return driver.leftStick();
+  //}
 
   @Override
   public Trigger indexerDown() {
@@ -192,5 +192,10 @@ public class SingleControl implements ControlBoard {
   @Override
   public Trigger resetIndexer() {
     return driver.povLeft();
+  }
+
+  @Override
+  public Trigger zeroElevator(){
+    return driver.leftStick();
   }
 }


### PR DESCRIPTION
Closes #180 and #176 
Binded the zero elevator command to left stick for all control modes.
Modified LED flash command to get rid of duration, instead added withTimeout() when needed to stop. Added an LED flash command to run in a parallel race group with intake command, making the LEDs flash turquoise and white until intake stops.
