### PR TITLE
Add Auto-X-break when stopped and intaking

### DIFF
--- a/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/RobotContainer.java
@@ -244,6 +244,7 @@ public class RobotContainer {
             vision,
             elevator,
             intake,
+            wrist,
             () -> -control.translationY(),
             () -> -control.translationX(),
             () -> -control.rotation(),

--- a/src/main/java/org/jmhsrobotics/frc2025/commands/DriveMeToTheMoon.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/commands/DriveMeToTheMoon.java
@@ -222,8 +222,8 @@ public class DriveMeToTheMoon extends Command {
             .orElse(new Pose3d()); // TODO: handle null tag pose
     Logger.recordOutput("Align/targetPos", defaultTagPose.plus(new Transform3d(goalTransform)));
 
-    if (speeds.vxMetersPerSecond == 0
-        && speeds.vyMetersPerSecond == 0
+    if (speeds.vxMetersPerSecond <= 0.1
+        && speeds.vyMetersPerSecond <= 0.1
         && wrist.getSetpoint() == Constants.WristConstants.kRotationIntakeCoralDegrees) {
       drive.stopWithX();
     }

--- a/src/main/java/org/jmhsrobotics/frc2025/commands/DriveMeToTheMoon.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/commands/DriveMeToTheMoon.java
@@ -222,8 +222,9 @@ public class DriveMeToTheMoon extends Command {
             .orElse(new Pose3d()); // TODO: handle null tag pose
     Logger.recordOutput("Align/targetPos", defaultTagPose.plus(new Transform3d(goalTransform)));
 
-    if (speeds.vxMetersPerSecond <= 0.1
-        && speeds.vyMetersPerSecond <= 0.1
+    if (Math.sqrt(Math.pow(speeds.vxMetersPerSecond, 2) + Math.pow(speeds.vyMetersPerSecond, 2))
+            < 0.01
+        && Math.abs(speeds.omegaRadiansPerSecond) < 0.01
         && wrist.getSetpoint() == Constants.WristConstants.kRotationIntakeCoralDegrees) {
       drive.stopWithX();
     }

--- a/src/main/java/org/jmhsrobotics/frc2025/commands/DriveMeToTheMoon.java
+++ b/src/main/java/org/jmhsrobotics/frc2025/commands/DriveMeToTheMoon.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import java.util.function.DoubleSupplier;
+import org.jmhsrobotics.frc2025.Constants;
 import org.jmhsrobotics.frc2025.commands.autoAlign.AlignSource;
 import org.jmhsrobotics.frc2025.commands.autoAlign.AutoAlign;
 import org.jmhsrobotics.frc2025.subsystems.drive.Drive;
@@ -23,6 +24,7 @@ import org.jmhsrobotics.frc2025.subsystems.elevator.Elevator;
 import org.jmhsrobotics.frc2025.subsystems.intake.Intake;
 import org.jmhsrobotics.frc2025.subsystems.vision.Vision;
 import org.jmhsrobotics.frc2025.subsystems.vision.VisionConstants;
+import org.jmhsrobotics.frc2025.subsystems.wrist.Wrist;
 import org.littletonrobotics.junction.Logger;
 
 public class DriveMeToTheMoon extends Command {
@@ -30,6 +32,8 @@ public class DriveMeToTheMoon extends Command {
   private final Vision vision;
   private final Elevator elevator;
   private final Intake intake;
+  private final Wrist wrist;
+
   private Trigger autoIntakeAlgae;
 
   private final PIDController xController = new PIDController(0.6, 0, 0.005);
@@ -51,6 +55,7 @@ public class DriveMeToTheMoon extends Command {
       Vision vision,
       Elevator elevator,
       Intake intake,
+      Wrist wrist,
       DoubleSupplier xSupplier,
       DoubleSupplier ySupplier,
       DoubleSupplier omegaSupplier,
@@ -61,6 +66,7 @@ public class DriveMeToTheMoon extends Command {
     this.vision = vision;
     this.elevator = elevator;
     this.intake = intake;
+    this.wrist = wrist;
     this.autoIntakeAlgae = autoIntakeAlge;
 
     this.xSupplier = xSupplier;
@@ -215,5 +221,11 @@ public class DriveMeToTheMoon extends Command {
             .getTagPose(targetId)
             .orElse(new Pose3d()); // TODO: handle null tag pose
     Logger.recordOutput("Align/targetPos", defaultTagPose.plus(new Transform3d(goalTransform)));
+
+    if (speeds.vxMetersPerSecond == 0
+        && speeds.vyMetersPerSecond == 0
+        && wrist.getSetpoint() == Constants.WristConstants.kRotationIntakeCoralDegrees) {
+      drive.stopWithX();
+    }
   }
 }


### PR DESCRIPTION
Add an if statement to the drive command so that if the wrist is in coral intaking position and there is no driver input, the robot will bring the wheels in an X to prevent movement. Closes #304 